### PR TITLE
Allow to define multiple sizes for a slot

### DIFF
--- a/lib/dfp_helper.rb
+++ b/lib/dfp_helper.rb
@@ -11,11 +11,11 @@ module DfpHelper
     end
     def dfp_helper_slot(_i, options = {})
       @@dfp_helper_id ||= (Time.now.to_f*1000).to_i
-      
+
       _id = "div-gpt-ad-#{@@dfp_helper_id}-#{dfp_helper_slots.size}"
       _size = options[:size] || _i.match(/\d+x\d+/)[0].split('x')
       dfp_helper_slots << options.merge({:id => _i, :div_id => _id, :size => _size})
-      
+
       raw <<-END.strip
 <!-- #{_i} -->
 <div id='#{_id}' style='width:#{_size[0]}px; height:#{_size[1]}px;'>
@@ -25,14 +25,14 @@ googletag.cmd.push(function() { googletag.display('#{_id}'); });
 </div>
       END
     end
-    
+
     def dfp_helper_head
       return unless dfp_helper_slots.size > 0
       o = dfp_helper_slots.collect{|i|
         _targeting = (i[:targeting]||[]).collect{|k,v| ".setTargeting(#{k.to_json}, #{v.to_json})"}.join
-        "googletag.defineSlot('#{i[:id]}', [#{i[:size].join(', ')}], '#{i[:div_id]}').addService(googletag.pubads())#{_targeting};"
+        "googletag.defineSlot('#{i[:id]}', [#{i[:size].map(&:to_s).join(', ')}], '#{i[:div_id]}').addService(googletag.pubads())#{_targeting};"
       }.join("\n")
-      
+
       raw <<-END.strip
 <script type='text/javascript'>
 var googletag = googletag || {};
@@ -42,7 +42,7 @@ var gads = document.createElement('script');
 gads.async = true;
 gads.type = 'text/javascript';
 var useSSL = 'https:' == document.location.protocol;
-gads.src = (useSSL ? 'https:' : 'http:') + 
+gads.src = (useSSL ? 'https:' : 'http:') +
 '//www.googletagservices.com/tag/js/gpt.js';
 var node = document.getElementsByTagName('script')[0];
 node.parentNode.insertBefore(gads, node);


### PR DESCRIPTION
According to the documentation, multiple sizes can be used for the same slot by using a multidimensional array, e.g.:

```
googletag.defineSlot("/1234/travel/asia/food", [[468, 60], [728, 90], [300, 250]], "div-gpt-ad-123456789-1");
```

This change adds support for that in the gem. Previously, trying to send a multidimensional array like the above would end up generating the following Javascript array:

```
[468, 60, 728, 90, 300, 250]
```

It is mentioned here http://support.google.com/dfp_premium/bin/answer.py?hl=en&answer=1697712 on "Define ad sizes in Google Publisher Tags"
And there's an example here http://support.google.com/dfp_premium/bin/answer.py?hl=en&answer=1638622 under "Example of an asynchronous Google Publisher Tag"
