### PR TITLE
Fixed Typo in readme: Spelling of License.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -48,6 +48,6 @@ For example:
 
 
 
-== Licence
+== License
 
 This project rocks and uses MIT-LICENSE.


### PR DESCRIPTION
Submitting PR to fix typo in README.rdoc.